### PR TITLE
🎨 Palette: Add aria-labels to structural icon-only buttons

### DIFF
--- a/.Jules/palette.md
+++ b/.Jules/palette.md
@@ -1,0 +1,3 @@
+## 2024-05-18 - Adding ARIA Labels to Icon-Only Buttons
+**Learning:** Found a recurring pattern in the app's components where common layout toggles (sidebar toggles, search clear buttons) rely solely on SVGs for visual communication. Screen reader users would have no context for these interactive elements. Adding `aria-label` is a simple but critical fix for these structural layout components.
+**Action:** When implementing new floating action buttons or structural toggles that contain only icons, ensure `aria-label` is included by default during component creation to avoid this pattern repeating.

--- a/compare.html
+++ b/compare.html
@@ -58,10 +58,10 @@
                     <div class="font-mono text-xs text-[#737373]"><span class="app-version"></span></div>
                 </div>
             </a>
-            <button id="closeSidebarMobile" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
+            <button id="closeSidebarMobile" aria-label="Close sidebar menu" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
             </button>
-            <button id="collapseSidebarDesktop" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
+            <button id="collapseSidebarDesktop" aria-label="Collapse sidebar" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>
@@ -165,7 +165,7 @@
         <!-- Mobile Header -->
         <div class="md:hidden flex items-center justify-between p-4 border-b border-[#222] bg-[#0a0a0a] shrink-0 z-10 sticky top-0">
             <div class="flex items-center gap-3">
-                <button id="openSidebarMobile" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
+                <button id="openSidebarMobile" aria-label="Open sidebar menu" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
                     <svg viewBox="0 0 24 24" width="22" height="22" stroke="currentColor" stroke-width="2" fill="none"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
                 </button>
                 <div class="flex items-center gap-2">
@@ -177,7 +177,7 @@
 
         <!-- Desktop Toggle Btn (Floating) -->
         <div id="desktopToggleContainer" class="hidden absolute top-[14px] left-4 z-20 transition-opacity duration-300">
-            <button id="openSidebarDesktop" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
+            <button id="openSidebarDesktop" aria-label="Open sidebar" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>

--- a/help.html
+++ b/help.html
@@ -58,10 +58,10 @@
                     <div class="font-mono text-xs text-[#737373]"><span class="app-version"></span></div>
                 </div>
             </a>
-            <button id="closeSidebarMobile" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
+            <button id="closeSidebarMobile" aria-label="Close sidebar menu" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
             </button>
-            <button id="collapseSidebarDesktop" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
+            <button id="collapseSidebarDesktop" aria-label="Collapse sidebar" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>
@@ -165,7 +165,7 @@
         <!-- Mobile Header -->
         <div class="md:hidden flex items-center justify-between p-4 border-b border-[#222] bg-[#0a0a0a] shrink-0 z-10 sticky top-0">
             <div class="flex items-center gap-3">
-                <button id="openSidebarMobile" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
+                <button id="openSidebarMobile" aria-label="Open sidebar menu" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
                     <svg viewBox="0 0 24 24" width="22" height="22" stroke="currentColor" stroke-width="2" fill="none"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
                 </button>
                 <div class="flex items-center gap-2">
@@ -177,7 +177,7 @@
 
         <!-- Desktop Toggle Btn (Floating) -->
         <div id="desktopToggleContainer" class="hidden absolute top-[14px] left-4 z-20 transition-opacity duration-300">
-            <button id="openSidebarDesktop" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
+            <button id="openSidebarDesktop" aria-label="Open sidebar" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>

--- a/index.html
+++ b/index.html
@@ -114,10 +114,10 @@
                     <div class="font-mono text-xs text-[#737373]"><span class="app-version"></span></div>
                 </div>
             </a>
-            <button id="closeSidebarMobile" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
+            <button id="closeSidebarMobile" aria-label="Close sidebar menu" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
             </button>
-            <button id="collapseSidebarDesktop" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
+            <button id="collapseSidebarDesktop" aria-label="Collapse sidebar" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>
@@ -142,7 +142,7 @@
                     <line x1="21" y1="21" x2="16.65" y2="16.65"></line>
                 </svg>
                 <input type="text" id="searchInput" placeholder="Search the index... (/)" autocomplete="off" class="w-full bg-black border border-[#222] rounded-md py-2.5 pl-9 pr-8 text-white font-sans text-[15px] transition-colors duration-200 outline-none focus:border-[#a3a3a3] placeholder-[#737373]">
-                <button class="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-none text-[#737373] text-sm cursor-pointer p-0.5 hidden hover:text-white" id="searchClear" title="Clear search">&#x2715;</button>
+                <button class="absolute right-3 top-1/2 -translate-y-1/2 bg-transparent border-none text-[#737373] text-sm cursor-pointer p-0.5 hidden hover:text-white" id="searchClear" aria-label="Clear search" title="Clear search">&#x2715;</button>
             </div>
         </div>
 
@@ -242,7 +242,7 @@
         <!-- Mobile Header -->
         <div class="md:hidden flex items-center justify-between p-4 border-b border-[#222] bg-[#0a0a0a] shrink-0 z-10 sticky top-0">
             <div class="flex items-center gap-3">
-                <button id="openSidebarMobile" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
+                <button id="openSidebarMobile" aria-label="Open sidebar menu" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
                     <svg viewBox="0 0 24 24" width="22" height="22" stroke="currentColor" stroke-width="2" fill="none"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
                 </button>
                 <div class="flex items-center gap-2">
@@ -254,7 +254,7 @@
 
         <!-- Desktop Toggle Btn (Floating) -->
         <div id="desktopToggleContainer" class="hidden absolute top-[14px] left-4 z-20 transition-opacity duration-300">
-            <button id="openSidebarDesktop" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
+            <button id="openSidebarDesktop" aria-label="Open sidebar" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>

--- a/settings.html
+++ b/settings.html
@@ -58,10 +58,10 @@
                     <div class="font-mono text-xs text-[#737373]"><span class="app-version"></span></div>
                 </div>
             </a>
-            <button id="closeSidebarMobile" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
+            <button id="closeSidebarMobile" aria-label="Close sidebar menu" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
             </button>
-            <button id="collapseSidebarDesktop" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
+            <button id="collapseSidebarDesktop" aria-label="Collapse sidebar" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>
@@ -165,7 +165,7 @@
         <!-- Mobile Header -->
         <div class="md:hidden flex items-center justify-between p-4 border-b border-[#222] bg-[#0a0a0a] shrink-0 z-10 sticky top-0">
             <div class="flex items-center gap-3">
-                <button id="openSidebarMobile" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
+                <button id="openSidebarMobile" aria-label="Open sidebar menu" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
                     <svg viewBox="0 0 24 24" width="22" height="22" stroke="currentColor" stroke-width="2" fill="none"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
                 </button>
                 <div class="flex items-center gap-2">
@@ -177,7 +177,7 @@
 
         <!-- Desktop Toggle Btn (Floating) -->
         <div id="desktopToggleContainer" class="hidden absolute top-[14px] left-4 z-20 transition-opacity duration-300">
-            <button id="openSidebarDesktop" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
+            <button id="openSidebarDesktop" aria-label="Open sidebar" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>

--- a/tools/hallucination-scorer.html
+++ b/tools/hallucination-scorer.html
@@ -343,10 +343,10 @@
                         <div class="font-mono text-xs text-[#737373]"><span class="app-version"></span></div>
                     </div>
                 </a>
-                <button id="closeSidebarMobile" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
+                <button id="closeSidebarMobile" aria-label="Close sidebar menu" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
                     <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
                 </button>
-                <button id="collapseSidebarDesktop"
+                <button id="collapseSidebarDesktop" aria-label="Collapse sidebar"
                     class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0"
                     title="Close sidebar">
                     <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
@@ -465,7 +465,7 @@
         <!-- Mobile Header -->
         <div class="md:hidden flex items-center justify-between p-4 border-b border-[#222] bg-[#0a0a0a] shrink-0 z-10 sticky top-0">
             <div class="flex items-center gap-3">
-                <button id="openSidebarMobile"
+                <button id="openSidebarMobile" aria-label="Open sidebar menu"
                     class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
                     <svg viewBox="0 0 24 24" width="22" height="22" stroke="currentColor" stroke-width="2" fill="none"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
                 </button>
@@ -478,7 +478,7 @@
 
         <!-- Desktop Toggle Btn (Floating) -->
         <div id="desktopToggleContainer" class="hidden absolute top-[14px] left-4 z-20 transition-opacity duration-300">
-            <button id="openSidebarDesktop"
+            <button id="openSidebarDesktop" aria-label="Open sidebar"
                 class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm"
                 title="Open sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>

--- a/tools/token-counter.html
+++ b/tools/token-counter.html
@@ -326,10 +326,10 @@
                         <div class="font-mono text-xs text-[#737373]"><span class="app-version"></span></div>
                     </div>
                 </a>
-                <button id="closeSidebarMobile" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
+                <button id="closeSidebarMobile" aria-label="Close sidebar menu" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
                     <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
                 </button>
-                <button id="collapseSidebarDesktop"
+                <button id="collapseSidebarDesktop" aria-label="Collapse sidebar"
                     class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0"
                     title="Close sidebar">
                     <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
@@ -448,7 +448,7 @@
         <!-- Mobile Header -->
         <div class="md:hidden flex items-center justify-between p-4 border-b border-[#222] bg-[#0a0a0a] shrink-0 z-10 sticky top-0">
             <div class="flex items-center gap-3">
-                <button id="openSidebarMobile"
+                <button id="openSidebarMobile" aria-label="Open sidebar menu"
                     class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
                     <svg viewBox="0 0 24 24" width="22" height="22" stroke="currentColor" stroke-width="2" fill="none"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
                 </button>
@@ -461,7 +461,7 @@
 
         <!-- Desktop Toggle Btn (Floating) -->
         <div id="desktopToggleContainer" class="hidden absolute top-[14px] left-4 z-20 transition-opacity duration-300">
-            <button id="openSidebarDesktop"
+            <button id="openSidebarDesktop" aria-label="Open sidebar"
                 class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm"
                 title="Open sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>

--- a/zap.html
+++ b/zap.html
@@ -58,10 +58,10 @@
                     <div class="font-mono text-xs text-[#737373]"><span class="app-version"></span></div>
                 </div>
             </a>
-            <button id="closeSidebarMobile" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
+            <button id="closeSidebarMobile" aria-label="Close sidebar menu" class="md:hidden text-[#737373] hover:text-white p-2 shrink-0">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><line x1="18" y1="6" x2="6" y2="18"></line><line x1="6" y1="6" x2="18" y2="18"></line></svg>
             </button>
-            <button id="collapseSidebarDesktop" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
+            <button id="collapseSidebarDesktop" aria-label="Collapse sidebar" class="hidden md:block text-[#a3a3a3] hover:text-white p-1.5 rounded-md hover:bg-white/5 transition-colors shrink-0" title="Close sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>
@@ -165,7 +165,7 @@
         <!-- Mobile Header -->
         <div class="md:hidden flex items-center justify-between p-4 border-b border-[#222] bg-[#0a0a0a] shrink-0 z-10 sticky top-0">
             <div class="flex items-center gap-3">
-                <button id="openSidebarMobile" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
+                <button id="openSidebarMobile" aria-label="Open sidebar menu" class="text-[#a3a3a3] hover:text-white transition-colors p-1 rounded-md hover:bg-white/5">
                     <svg viewBox="0 0 24 24" width="22" height="22" stroke="currentColor" stroke-width="2" fill="none"><line x1="3" y1="12" x2="21" y2="12"></line><line x1="3" y1="6" x2="21" y2="6"></line><line x1="3" y1="18" x2="21" y2="18"></line></svg>
                 </button>
                 <div class="flex items-center gap-2">
@@ -177,7 +177,7 @@
 
         <!-- Desktop Toggle Btn (Floating) -->
         <div id="desktopToggleContainer" class="hidden absolute top-[14px] left-4 z-20 transition-opacity duration-300">
-            <button id="openSidebarDesktop" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
+            <button id="openSidebarDesktop" aria-label="Open sidebar" class="text-[#a3a3a3] hover:text-white p-1.5 bg-[#0a0a0a] border border-[#222] rounded-md shadow-sm transition-all hover:bg-white/5 backdrop-blur-sm" title="Open sidebar">
                 <svg viewBox="0 0 24 24" width="20" height="20" stroke="currentColor" stroke-width="2" fill="none"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"></rect><line x1="9" y1="3" x2="9" y2="21"></line></svg>
             </button>
         </div>


### PR DESCRIPTION
💡 What: Added `aria-label` attributes to common SVG-only buttons across the main application pages (sidebar toggles, search clear).
🎯 Why: Without these labels, screen reader users encounter buttons with no discernible name or context, making navigation and interaction difficult.
♿ Accessibility: Improves accessibility for assistive technology users by providing clear, descriptive labels for structural layout controls.

Related: Addressed recurring pattern of missing a11y labels on toggle buttons.

---
*PR created automatically by Jules for task [7753472190751877206](https://jules.google.com/task/7753472190751877206) started by @QAInsights*