### PR TITLE
docs(readme): add lucinate to Terminal & CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ AI coding agents that live in your terminal or command line.
 | **[Crush](https://github.com/charmbracelet/crush)** | Charmbracelet | CLI tool for MCP-based coding workflows |
 | **[iFlow CLI](https://github.com/iflow-ai/iflow-cli)** | iFlow | Terminal AI agent for workflow automation |
 | **[Kiro CLI](https://kiro.dev/cli/)** | AWS | Command-line agent interface with MCP capabilities |
+| **[lucinate](https://github.com/lucinate-ai/lucinate)** | lucinate-ai | Terminal-native TUI chat client for AI agents; connects to OpenClaw, Hermes, and any OpenAI-compatible endpoint; Homebrew tap available |
 | **[MCPJam](https://www.mcpjam.com)** | MCPJam | CLI agent optimized for Model Context Protocol integration |
 | **[Mistral Vibe](https://github.com/mistralai/mistral-vibe)** | Mistral | Terminal agent leveraging Mistral models |
 | **[Mux](https://coder.com/products/mux)** | Coder | Advanced terminal AI assistant and multiplexer |


### PR DESCRIPTION
Add [lucinate](https://github.com/lucinate-ai/lucinate) — a terminal-native TUI chat client written in Go for interacting with AI agents.

lucinate connects to OpenClaw gateways, Hermes agent profiles, and any OpenAI-compatible endpoint (Ollama, vLLM, LM Studio, OpenAI). It provides streaming responses, markdown rendering, tool call cards, local skills, cron management, session browsing, and multi-agent support — all from the terminal.

**Section:** Terminal & CLI Agents
**Public signal:** Active GitHub development, Homebrew tap, cross-platform install scripts, website at lucinate.ai, MIT licensed