### PR TITLE
Add Lervos under Invoicing / Proposals

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,13 @@
 > A curated, categorized reference of AI-powered coding tools as of **May 2026**.
 > Covers full IDEs, editor extensions, terminal agents, autonomous agents, browser-based builders, and code review platforms.  
 
-> **100+ tools** across 12 categories.
+> **100+ tools** across 13 categories.
 
 ## 📋 Table of Contents
 
 - [🖥️ AI-Native IDEs & Editors](#ai-native-ides--editors)
 - [🔌 IDE Extensions & Plugins](#ide-extensions--plugins)
+- [🧾 Invoicing / Proposals](#invoicing--proposals)
 - [💻 Terminal & CLI Agents](#terminal--cli-agents)
 - [🤖 Autonomous & Async Agents](#autonomous--async-agents)
 - [🌐 Browser-Based & App Builders](#browser-based--app-builders)
@@ -79,6 +80,13 @@ Plug-in assistants that enhance your existing editor (VS Code, JetBrains, Neovim
 | **[Oh My codeX](https://github.com/Yeachan-Heo/oh-my-codex)** | Yeachan-Heo | OmX: Your codex is not alone. Add hooks, agent teams, HUDs, and so much more |
 | **[Bob](https://bob.ibm.com/)** | IBM | Your AI-Powered Development Partner |
 | **[Firebender](https://firebender.com/)** | Firebender | The first Android-native coding agent that writes features, tests them in the emulator, and fixes issues automatically |
+
+---
+
+## 🧾 Invoicing / Proposals
+AI-assisted tools for client proposals, quotes, and freelance bids.
+
+* [Lervos](https://lervos.com) - AI-powered proposal assistant that automates high-converting project bids for freelancers.
 
 ---
 

--- a/data/slugs.json
+++ b/data/slugs.json
@@ -258,6 +258,12 @@
     "category": "IDE Extensions & Plugins"
   },
   {
+    "slug": "lervos",
+    "name": "Lervos",
+    "company": "Lervos",
+    "category": "Invoicing / Proposals"
+  },
+  {
     "slug": "claude-code",
     "name": "Claude Code",
     "company": "Anthropic",

--- a/js/category.js
+++ b/js/category.js
@@ -10,7 +10,8 @@ const categoryMapping = {
     'General-Purpose AI Assistants (with Strong Coding Capability)': 'General AI',
     'AI Codebase Knowledge & Generation': 'Codebase AI',
     'Developer Productivity & Workflow': 'Productivity',
-    'Editor Platforms with Native AI Features': 'Native Editors'
+    'Editor Platforms with Native AI Features': 'Native Editors',
+    'Invoicing / Proposals': 'Proposals'
 };
 
 export function getShortCategory(category) {

--- a/js/parser.js
+++ b/js/parser.js
@@ -76,6 +76,22 @@ export function parseMarkdown(md) {
                 isTable = false;
             }
         }
+
+        // Bullet list entries: * [Name](url) - notes
+        for (const line of lines) {
+            const trimmed = line.trim();
+            const bulletMatch = trimmed.match(/^\* \[(.*?)\]\((.*?)\) - (.+)$/);
+            if (bulletMatch) {
+                const name = bulletMatch[1].replace(/\*\*/g, '');
+                tools.push({
+                    category: categoryLine,
+                    name,
+                    url: bulletMatch[2],
+                    company: name,
+                    notes: bulletMatch[3].trim(),
+                });
+            }
+        }
     }
 
     // Assign slugs with collision resolution. First occurrence keeps the clean

--- a/js/parser.test.js
+++ b/js/parser.test.js
@@ -120,6 +120,21 @@ describe('parser', () => {
             expect(tools[0].name).toBe('Cursor');
         });
 
+        test('should parse bullet list tool entries', () => {
+            const md = `## 🧾 Invoicing / Proposals
+
+* [Lervos](https://lervos.com) - AI-powered proposal assistant for freelancers.
+`;
+            const tools = parseMarkdown(md);
+            expect(tools.length).toBe(1);
+            expect(tools[0].name).toBe('Lervos');
+            expect(tools[0].url).toBe('https://lervos.com');
+            expect(tools[0].company).toBe('Lervos');
+            expect(tools[0].notes).toBe('AI-powered proposal assistant for freelancers.');
+            expect(tools[0].category).toBe('🧾 Invoicing / Proposals');
+            expect(tools[0].slug).toBe('lervos');
+        });
+
         test('should assign unique slugs with collision resolution', () => {
             const md = `## Category A
 
@@ -202,6 +217,7 @@ Some text without tables.
             expect(getShortCategory('AI-Native IDEs & Editors')).toBe('AI IDEs');
             expect(getShortCategory('IDE Extensions & Plugins')).toBe('IDE Plugins');
             expect(getShortCategory('Terminal & CLI Agents')).toBe('CLI Agents');
+            expect(getShortCategory('🧾 Invoicing / Proposals')).toBe('Proposals');
         });
 
         test('should handle partial category matches', () => {

--- a/src/lib/tools.ts
+++ b/src/lib/tools.ts
@@ -64,6 +64,7 @@ const CATEGORY_MAPPING: Record<string, string> = {
     'AI Codebase Knowledge & Generation': 'Codebase AI',
     'Developer Productivity & Workflow': 'Productivity',
     'Editor Platforms with Native AI Features': 'Native Editors',
+    'Invoicing / Proposals': 'Proposals',
 };
 
 /**
@@ -145,6 +146,23 @@ function parseMarkdown(text: string): ToolSeed[] {
                 }
             } else if (isTable && (!line.trim().startsWith('|') && line.trim() !== '')) {
                 isTable = false;
+            }
+        }
+
+        for (const line of lines) {
+            const trimmed = line.trim();
+            const bulletMatch = trimmed.match(/^\* \[(.*?)\]\((.*?)\) - (.+)$/);
+            if (bulletMatch) {
+                const name = bulletMatch[1].replace(/\*\*/g, '');
+                toolsRaw.push({
+                    name,
+                    url: bulletMatch[2],
+                    company: name,
+                    notes: bulletMatch[3].trim(),
+                    category: categoryLine,
+                    categoryClean: stripEmoji(categoryLine),
+                    categoryShort: getShortCategory(categoryLine),
+                });
             }
         }
     }

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -39,7 +39,7 @@ const jsonLd = JSON.stringify({
             "@id": "https://ai.dosa.dev/#collection",
             "url": "https://ai.dosa.dev",
             "name": "Awesome AI Tools Directory",
-            "description": `${tools.length}+ manually curated AI-powered coding tools across 12 categories.`,
+            "description": `${tools.length}+ manually curated AI-powered coding tools across 13 categories.`,
             "isPartOf": { "@id": "https://ai.dosa.dev/#website" },
             "publisher": { "@id": "https://ai.dosa.dev/#organization" },
             "about": { "@type": "Thing", "name": "AI-powered developer tools" },


### PR DESCRIPTION
Introduce a dedicated README section for proposal tooling with Lervos listed in the requested bullet format. Extend the Markdown parser to ingest * [Name](url) - notes entries so the site slug catalog stays in sync. Map the new category to short label Proposals and refresh slugs.json.

I liked your repo and I thought I would add to it if not possible its okay as well I wish you a good continuation!