### PR TITLE
Add AgentBox to Terminal & CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ AI coding agents that live in your terminal or command line.
 | **[AdaL](https://sylph.ai/)** | Sylph | Autonomous developer agent for the CLI |
 | **[Cline Kanban](https://cline.bot/kanban)** | Cline | Cline Kanban works with the agents you're already using: Claude Code, Codex, and Cline-compatible agents, with more to come. |
 | **[Parallel Code](https://parallelcode.app/)** | Parallel Code | Parallel Code is a desktop app that gives every AI coding agent its own git branch and worktree — automatically.|
+| **[AgentBox](https://github.com/madarco/agentbox)** | madarco | Runs multiple coding agents (Claude Code, Codex, OpenCode) in parallel, each in its own sandboxed VM — local Docker, self-hosted, or cloud. Sub-1s checkpoints, per-box browser/VS Code/shells, git creds kept on host. MIT. |
 | **[Pi](https://pi.dev/)** | badlogic | Pi is a minimal terminal coding harness. Adapt pi to your workflows, not the other way around. |
 | **[Autohand ACP](https://github.com/autohandai/autohand-acp)** | Autohand | ACP-based terminal coding agent with autonomous capabilities |
 | **[Crow CLI](https://github.com/crow-cli/crow-cli)** | Crow | Two-layer system: ACP agent (crow-cli) that does the thinking, and MCP toolserver (crow-mcp) that does the doing |


### PR DESCRIPTION
Adds [AgentBox](https://github.com/madarco/agentbox) to **Terminal & CLI Agents**, alongside Parallel Code and other terminal-native runners.

Runs multiple coding agents (Claude Code, Codex, OpenCode) in parallel, each in its own sandboxed VM — local Docker, self-hosted, or cloud. Sub-1s checkpoints, per-box browser/VS Code/shells, git credentials kept on the host. MIT.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the “Terminal & CLI Agents” list in the README with a new AgentBox entry, including its website, company name, and a brief description of its parallel coding-agent workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->