### PR TITLE
Add NotFair to IDE Extensions & Plugins

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ Plug-in assistants that enhance your existing editor (VS Code, JetBrains, Neovim
 | **[Apertis](https://apertis.ai/)** | Stima | One API key works across all major coding agents |
 | **[Corust](https://corust.ai/)** | Corust | Your seasoned Rust co-pilot: production-grade code generation, zero hallucinations on Rust idioms, and tools built for real Rustaceans. |
 | **[Toprank](https://github.com/nowork-studio/toprank)** | nowork-studio | Open-source Claude Code plugin for SEO, Google Ads, content writing, and CMS optimization workflows |
+| **[NotFair](https://github.com/nowork-studio/NotFair)** | nowork-studio | Open-source Claude Code skills for SEO, GEO/AEO, and paid ads; bundles Google Search Console, Google Analytics (GA4), Google Ads, and Meta Ads MCP servers for live account data |
 | **[WozCode](https://www.wozcode.com/)** | WozCode | A Claude Code plugin that supercharges performance, cost, and speed |
 | **[Claude Code Skills 中文精选集](https://claude-skills.bt199.com/)** | 老实人实验室 | Chinese curated directory of Claude Code Skills, Agents, Plugins, and workflows with 140+ resources |
 | **[Oh My codeX](https://github.com/Yeachan-Heo/oh-my-codex)** | Yeachan-Heo | OmX: Your codex is not alone. Add hooks, agent teams, HUDs, and so much more |


### PR DESCRIPTION
Thanks for keeping this so well organized — the category breakdown is genuinely useful.

You already list nowork-studio's **Toprank**; adding their newer, broader plugin **[NotFair](https://github.com/nowork-studio/NotFair)** (MIT, ~2.9k⭐) right below it in the same section. Where Toprank covers SEO + Google Ads, NotFair adds GEO/AEO and Meta Ads, and the skills bundle their own MCP servers — Google Search Console, Google Analytics (GA4), Google Ads, and Meta Ads — so the agent works off live account data.

One row, matched to your existing table format. Happy to tweak the wording.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added NotFair to the IDE Extensions & Plugins list, including a link and a description of its available tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->