### PR TITLE
Add Tura to Terminal & CLI Agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ AI coding agents that live in your terminal or command line.
 | **[Aider](https://aider.chat)** | Aider | Git-native terminal pair programmer; 39K GitHub stars; auto-commits changes |
 | **[Gemini CLI](https://github.com/google-gemini/gemini-cli)** | Google | Terminal agent for local repo tasks; lightweight; no UI overhead |
 | **[Goose](https://block.github.io/goose/)** | Block | Open-source AI agent framework; fully local; write/execute/debug from CLI |
+| **[Tura](https://github.com/Tura-AI/tura)** | Tura AI | Open-source local coding agent with CLI/TUI/GUI, task-scoped context, macro command execution, verification, and published benchmarks |
 | **[Amazon Q CLI](https://aws.amazon.com/q/developer/)** | AWS | CLI agent component of Amazon Q; AWS-integrated terminal tasks |
 | **[Letta Code](https://github.com/letta-ai/letta-code)** | Letta | Memory-first terminal coding agent; stateful across sessions; [Docs](https://docs.letta.com/letta-code) |
 | **[Qwen CLI](https://qwen.ai/qwencode)** | Alibaba | High-performance CLI tool for Qwen models; specialized in code generation |


### PR DESCRIPTION
Hi! I maintain Tura, an AGPL-3.0 local coding agent with CLI, TUI, and GUI entry points. It focuses on task-scoped context, macro command execution, and verification, with its benchmark methodology and results published at https://turaai.net/benchmark.

This PR adds one row to the Terminal & CLI Agents table and follows the existing table format.

Repository: https://github.com/Tura-AI/tura
Project site: https://turaai.net/

Thanks for considering it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Tura to the list of terminal and CLI coding agents.
  * Included details about its local operation, interfaces, task-scoped context, macro execution, verification, and benchmarks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->