### PR TITLE
fix(data): repair broken JSON syntax in tools.json

### DIFF
--- a/src/data/tools.json
+++ b/src/data/tools.json
@@ -543,6 +543,7 @@
     "companyName": "MountainOwl",
     "toolName": "Bubo"
   },
+  {
     "companyName": "FWDAI",
     "toolName": "Fletch"
   }


### PR DESCRIPTION
Fixes a missing opening brace for the FWDAI/Fletch entry that was causing process_submission.py to fail with JSONDecodeError when processing new submissions.