### PR TITLE
Add Sillage

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ AI coding agents that live in your terminal or command line.
 | **[AI Badger](https://pvrlabs.xyz/aibadger)** | PVR Labs | AI Badger is a local-first CLI that maps your codebase and extracts focused file context for AI chats and coding agents. It works with ChatGPT, Claude, Codex, Gemini, and other assistants without cloud indexing, API keys, or vendor lock-in.; [GitHub](https://github.com/PVRLabs/aibadger) |
 | **[AgentBox](https://agent-box.sh)** | Marco D'Alia | Run multiple coding agents (Claude Code, Codex, OpenCode) in parallel, each teleported into its own sandboxed VM — local Docker, self-hosted, or cloud (Hetzner/Daytona/E2B). Sub-second checkpoints, per-box browser/VS Code/persistent shells, native macOS menu-bar app, git credentials kept on the host. MIT.; [GitHub](https://github.com/madarco/agentbox) |
 | **[Oh My Pi](https://github.com/can1357/oh-my-pi)** | Can Bölük | ⌥ AI Coding agent for the terminal — hash-anchored edits, optimized tool harness, LSP, Python, browser, subagents, and more.; [GitHub](_No response_) |
+| **[Sillage](https://github.com/MarlBurroW/sillage)** | MarlBurroW | Self-hosted, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine (replaces the terminal, not the agent). Sessions that outlive the client, full-text search across every conversation, an IDE panel (file explorer, editor, diffs, terminal), a board the agents read through its own MCP server, installable PWA with push. Single Docker container. MIT.; [GitHub](https://github.com/MarlBurroW/sillage) |
 
 ---
 


### PR DESCRIPTION
Adds **Sillage** as a new row in the `## 💻 Terminal & CLI Agents` table (it already lists companion web/desktop UIs for Claude Code and Codex such as Parallel Code, AgentBox and Cline Kanban).

Sillage is a self-hosted, MIT-licensed, mobile-first web UI that drives the native Claude Code and Codex CLIs on your own machine (it replaces the terminal, not the agent): sessions that outlive the client, full-text search across every conversation, an IDE panel (file explorer, editor, diffs, terminal), a board the agents read through its own MCP server, and an installable PWA with push. Single Docker container.

- Repo: https://github.com/MarlBurroW/sillage
- License: MIT

Disclosure: I am the author of Sillage.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added Sillage to the Terminal & CLI Agents directory.
  * Included a link, maintainer information, and a feature description.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->